### PR TITLE
feat: update dio to 5.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  dio: ^4.0.6
+  dio: ^5.0.0
   fixnum: ^1.0.1
   logging: ^1.1.0
   protobuf: ^2.1.0


### PR DESCRIPTION
## Which problem is this PR solving?

migrate dio from 4.2.0 to 5.0.0

## Short description of the change
Dio Breaking Changes 
- Content type with application/json and application/x-www-form-urlencoded will not be implied anymore in the transformer and the request option.
- The default charset utf-8 in Headers content type constants has been removed.
- BaseOptions.setRequestContentTypeWhenNoPayload has been removed.
- Improve DioErrors. There are now more cases in which the inner original stacktrace is supplied.
- HttpClientAdapter must now be implemented instead of extended.
- Any classes specific to dart:io platforms can now be imported via import 'package:dio/io.dart';. Classes specific to web can - be imported via import 'package:dio/browser.dart';.
- connectTimeout, sendTimeout, and receiveTimeout are now Durations.

## How Has This Been Tested?

Please describe the tests that you ran to verify your change. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [ ] Unit tests have been added
- [ ] Documentation has been updated